### PR TITLE
デスクトップ版で左右カーソルが反応しない問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,14 @@
                         <img src="./image/loveyou_top_sp5.jpg" class="d-block img-fluid">
                     </div>
                 </div>
+                <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleInterval" data-bs-slide="prev">
+                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                    <span class="visually-hidden">Previous</span>
+                </button>
+                <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleInterval" data-bs-slide="next">
+                    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                    <span class="visually-hidden">Next</span>
+                </button>
             </div>
             <div id="carouselExampleFade" class="carousel slide carousel-fade" data-bs-ride="carousel">
                 <!-- PC用画像 -->
@@ -98,15 +106,15 @@
                         <img src="./image/loveyou_top5.jpg" class="d-block img-fluid">
                     </div>
                 </div>
+                <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleFade" data-bs-slide="prev">
+                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                    <span class="visually-hidden">Previous</span>
+                </button>
+                <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleFade" data-bs-slide="next">
+                    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                    <span class="visually-hidden">Next</span>
+                </button>
             </div>
-            <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleInterval" data-bs-slide="prev">
-                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                <span class="visually-hidden">Previous</span>
-            </button>
-            <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleInterval" data-bs-slide="next">
-                <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                <span class="visually-hidden">Next</span>
-            </button>
         </div>
     </div>
     <div class="row">


### PR DESCRIPTION
#### 背景
デスクトップ版で左右のカーソルキーが反応しない問題が発生しており、ユーザーが画像の切り替えを正常に行えない状態となっていました。

#### 変更内容
- 左右のカーソルキーがデスクトップ版で機能しない不具合を修正

#### テスト
- 検証ツールで、デスクトップ版とモバイル版に対して動作テストを実施し、左右カーソルキーが期待通りに機能することを確認しました。

#### 積み残し（TODO）
- 特になし

#### 関係資料
- 特になし